### PR TITLE
Minor label corrections for 'revert' and 'delete'

### DIFF
--- a/better-osm-org.user.js
+++ b/better-osm-org.user.js
@@ -187,7 +187,7 @@ function addRevertButton() {
     if (sidebar) {
         // sidebar.classList.add("changeset-header")
         let changeset_id = sidebar.innerHTML.match(/(\d+)/)[0];
-        sidebar.innerHTML += ` [<a href="https://revert.monicz.dev/?changesets=${changeset_id}" target=_blank class=revert_button_class>🔙</a>]`;
+        sidebar.innerHTML += ` [<a href="https://revert.monicz.dev/?changesets=${changeset_id}" target=_blank class=revert_button_class>↩️</a>]`;
         // find deleted user
         // todo extract
         let metainfoHTML = document.querySelector(".browse-section > .details")

--- a/better-osm-org.user.js
+++ b/better-osm-org.user.js
@@ -382,7 +382,7 @@ function addDeleteButton() {
 
     const auth = makeAuth();
     let link = document.createElement('a');
-    link.text = ['ru-RU', 'ru'].includes(navigator.language) ? "Выпилить!" : "Delete!";
+    link.text = ['ru-RU', 'ru'].includes(navigator.language) ? "Выпилить!" : "Delete";
     link.href = "";
     link.classList.add("delete_object_button_class");
     // skip deleted


### PR DESCRIPTION
- Changed revert button emoji to `↩️` (macOS gives you this emoji when you search for _undo_ in Character Viewer). The current one (`🔙`) means more like _go back to the previous page_, I think.
- Removed the exclamation mark from the end of _Delete!_ (node deletion button). No other buttons on that page use exclamation marks.