### PR TITLE
Improve performance of compact mode toggling

### DIFF
--- a/better-osm-org.user.js
+++ b/better-osm-org.user.js
@@ -2716,8 +2716,8 @@ function setupSatelliteLayers() {
 
 function makeElementHistoryCompact() {
     const shouldBeCompact = document.querySelector(".compact-toggle-btn").getAttribute("value") === "><";
-    document.querySelectorAll(".non-modified-tag").forEach((el) => {
-        el.classList.toggle("d-none", shouldBeCompact)
+    document.querySelectorAll("table.browse-tag-list").forEach((el) => {
+        el.classList.toggle("hide-non-modified-tags", shouldBeCompact)
     })
     document.querySelectorAll(".empty-version").forEach((el) => {
         el.classList.toggle("d-none", shouldBeCompact)
@@ -5664,7 +5664,11 @@ function addDiffInHistory() {
     .hidden-version, .hidden-h4 {
         display: none;
     }
-    
+
+    table.browse-tag-list.hide-non-modified-tags > tbody > .non-modified-tag {
+        display: none;
+    }
+
     #sidebar_content h2:not(.changeset-header){
         font-size: 1rem;
     }
@@ -5979,6 +5983,7 @@ function addDiffInHistory() {
                     })
                 }
                 if (!tagWasModified) {
+                    i.classList.add("non-modified-tag")
                     i.querySelector("th").classList.add("non-modified-tag")
                     i.querySelector("td").classList.add("non-modified-tag")
                 }
@@ -8291,7 +8296,11 @@ function addQuickLookStyles() {
             tr.quick-look-deleted-tag td:not(.tag-flag) {
                 background: rgba(238,51,9,0.6);
             }
-            
+
+            table.quick-look.hide-non-modified-tags > tbody > .non-modified-tag-in-quick-view {
+                display: none;
+            }
+
             .new-letter {
                 background: rgba(25, 223, 25, 0.6);
             }
@@ -8698,12 +8707,9 @@ async function processQuickLookInSidebar(changesetID) {
                 }
             })
             tagsOfObjectsVisible = !tagsOfObjectsVisible
-            document.querySelectorAll(".non-modified-tag-in-quick-view").forEach(i => {
-                if (e.target.textContent === "><") {
-                    i.removeAttribute("hidden")
-                } else {
-                    i.setAttribute("hidden", "true")
-                }
+            const shouldBeHidden = e.target.textContent === "<>"
+            document.querySelectorAll("table.quick-look").forEach(el => {
+                el.classList.toggle("hide-non-modified-tags", shouldBeHidden)
             });
             if (needHideNodes) {
                 if (e.target.textContent === "><") {


### PR DESCRIPTION
Instead of showing/hiding [total number of nonmodified tags] one by one, we can toggle a class per OSM element/OSM element version which automatically shows/hides these tags. Thus reducing DOM operations from [total number of nonmodified tags] to [total number of modified elements]

The style change is still slow on /node/.../history but that might be a Firefox issue

Links for testing:
https://www.openstreetmap.org/node/107775/history (300ms => 20ms)
https://www.openstreetmap.org/changeset/165370426 (1300ms+ => <5ms)